### PR TITLE
Full flow with verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ anyhow = "1.0"
 async-std = "1.12.0"
 base64 = "0.13.0"
 clap = "3.1.18"
+colored = "2.0.0"
 data-encoding = "2.3.2"
-sigstore = { git = "https://github.com/sigstore/sigstore-rs", branch = "main" }
+sigstore = { git = "https://github.com/lkatalin/sigstore-rs", branch = "fulcio_parse_openssl" }
 #sigstore = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/rekor_api.rs
+++ b/src/rekor_api.rs
@@ -3,7 +3,6 @@ use sigstore::rekor::models::{
     hashedrekord::{AlgorithmKind, Data, Hash, PublicKey, Signature, Spec},
     LogEntry, ProposedEntry,
 };
-use url::Url;
 
 pub async fn create_log(
     hash: &str,
@@ -12,14 +11,12 @@ pub async fn create_log(
 ) -> Result<LogEntry, anyhow::Error> {
     let configuration = Configuration::default();
 
-    const KEY_FORMAT: &str = "x509";
     const API_VERSION: &str = "0.0.1";
-    const URL: &str = "https://example.com";
 
     let hash = Hash::new(AlgorithmKind::sha256, hash.to_string());
-    let data = Data::new(hash, Url::parse(URL)?);
+    let data = Data::new(hash);
     let public_key = PublicKey::new(public_key.to_string());
-    let signature = Signature::new(KEY_FORMAT.to_string(), signature.to_string(), public_key);
+    let signature = Signature::new(signature.to_string(), public_key);
     let spec = Spec::new(signature, data);
     let proposed_entry = ProposedEntry::Hashedrekord {
         api_version: API_VERSION.to_string(),


### PR DESCRIPTION
In this PR:
- Add `verify` flag that, if present, will take extra steps to verify the signature created by extracting info from the Rekor entry
- Add colors to terminal output to make more easily readable
- Remove parts of `rekor_api` that are outdated

The last TODO is once https://github.com/sigstore/sigstore-rs/pull/153 is merged we can put the sigstore dependency back on the main HEAD.